### PR TITLE
fix: add presence count to members online string

### DIFF
--- a/app/examples/animal/forest/chat/fragments/ChatFragment.java
+++ b/app/examples/animal/forest/chat/fragments/ChatFragment.java
@@ -208,8 +208,9 @@ public class ChatFragment extends ParentFragment implements MessageComposer.List
             @Override
             public void presence(PubNub pubnub, PNPresenceEventResult presence) {
                 if (presence.getChannel().equals(mChannel)) {
+                    int members = presence.getOccupancy();
                     runOnUiThread(() -> hostActivity.setSubtitle(fragmentContext.getResources()
-                            .getQuantityString(R.plurals.members_online, presence.getOccupancy())));
+                            .getQuantityString(R.plurals.members_online, members, members)));
                 }
             }
         };
@@ -224,8 +225,9 @@ public class ChatFragment extends ParentFragment implements MessageComposer.List
                     @Override
                     public void onResponse(PNHereNowResult result, PNStatus status) {
                         if (!status.isError()) {
+                            int members = result.getTotalOccupancy();
                             hostActivity.setSubtitle(fragmentContext.getResources()
-                                    .getQuantityString(R.plurals.members_online, result.getTotalOccupancy()));
+                                    .getQuantityString(R.plurals.members_online, members, members));
                         }
                     }
                 });


### PR DESCRIPTION

* fixes a bug introduced in #21 causing the template string to not have the online user count inserted